### PR TITLE
Support Monacoin.

### DIFF
--- a/pycoin/networks/all.py
+++ b/pycoin/networks/all.py
@@ -185,6 +185,30 @@ BUILT_IN_NETWORKS = [
         ],
         bech32_hrp='bc'
     ),
+
+    # MONA Monacoin mainnet : Ltpv/Ltub
+    Network(
+        "MONA", "Monacoin", "mainnet",
+        b'\xb0', b'\x32', b'\37',
+        h2b('0488ade4'), h2b('0488b21e'),
+        LegacyBitcoinTx, BitcoinBlock,
+        h2b('fbc0b6db'), 9401, [
+            "dnsseed.monacoin.org",
+        ],
+        bech32_hrp='mona'
+    ),
+
+    # MONA Monacoin testnet : ttpv/ttub
+    Network(
+        "TMONA", "Monacoin", "testnet4",
+        b'\xef', b'\x6f', b'\75',
+        h2b('04358394'), h2b('043587cf'),
+        LegacyBitcoinTx, BitcoinBlock,
+        h2b('fdd2c8f1'), 19403, [
+            "testnet-dnsseed.monacoin.org",
+        ],
+        bech32_hrp='tmona'
+    ),
  
 ]
 


### PR DESCRIPTION
@superisaac pls, review

本地尝试创建OK，钱包私钥可以导入，这个私钥后面不会使用，主要用于演示:

```
(*'-') < ku create -nMONA                                                                                                                                                                18-08-07 17:47
                                                                                                  
input                         : create                                                                                                                                                                 
network                       : Monacoin mainnet                                                                                                                                                       
netcode                       : MONA                              
wallet key                    : xprv9s21ZrQH143K3uZNippwS953mAVeoWsADMjGCHaSrCNBmXYRK4AkdPbfBwohpv\
                                  AryPFfkwMi1uBNN2zhTQG2Xx43cFmTcz1A25QcZFKpQ5j
public version                : xpub661MyMwAqRbcGPdqprMwoH1nKCL9Cyb1aaerzfz4QXuAeKsZrbV1BBv93G863s\
                                  D4BYYktXR7QHDZv6Xj8Nem1ZePmWuCvquycKSaWvDvRUk
tree depth                    : 0    
fingerprint                   : 11f9119d                             
parent f'print                : 00000000                                                                                                                                                               
child index                   : 0       
chain code                    : b9a5a04b39575fa75d89104ebb980ae181fb20aae391b2611197e42fa073a185
private key                   : yes                         
secret exponent               : 6876150993485156571410297742822267514978145327572633336303132563182444503066                                                                                           
 hex                          : f33c37794b63bb8e05a1681e15abdc459797a3c865a74b2f374e285a242601a
wif                           : T3ZXbHFbLpRWHh3G6YbuCpBXK7et5GVmTp84wFuS6HQT34csL3kq
 uncompressed                 : 6uEiNMuF8D71HvUhaRqEe7cTohUcb3c4jKqGqzkbgiKua7KrB65
public pair x                 : 86853670024809925388406208406182823042057876798274630401634825881658824250084
public pair y                 : 52777235361615367707167725698025207369203966327120030245666578516864942608565
 x as hex                     : c0056f66a873253d303e9c0409c4b15cd142dba0d202972a42c0dad28102d2e4
 y as hex                     : 74aedb4c3220dd1ea6c639edff35bcc651819f99761966596a33464eeec210b5
y parity                      : odd                                                                                                                                                                    
key pair as sec               : 03c0056f66a873253d303e9c0409c4b15cd142dba0d202972a42c0dad28102d2e4                                                                                                     
 uncompressed                 : 04c0056f66a873253d303e9c0409c4b15cd142dba0d202972a42c0dad28102d2e4\
                                  74aedb4c3220dd1ea6c639edff35bcc651819f99761966596a33464eeec210b5
hash160                       : 11f9119dc9c1d435eea1508ffec01769e57309e3                                                                                                                               
 uncompressed                 : 5a0b77bdd1e8db381027fc8a625949bf97d35294                                                                                                                               
Monacoin address              : M9YC6J7by7LRxrBxajXQyGi554fv6pHTZa
Monacoin address uncompressed : MG7GnVE9BiYkEf7QMogPSnr1ic54B2VsfC
Monacoin segwit address       : mona1qz8u3r8wfc82rtm4p2z8lasqhd8jhxz0rskz9hg
p2sh segwit                   : DVzmcC6MFwECYze7uW78z1kPkP22Ry3JDF                                                                                                                                     
 corresponding p2sh script    : 001411f9119dc9c1d435eea1508ffec01769e57309e3
```

testnet:
```
(*'-') < ku create -nTMONA                                                                                                                                                               18-08-07 17:52

input                         : create
network                       : Monacoin testnet4
netcode                       : TMONA
wallet key                    : tprv8ZgxMBicQKsPdZwdiJwWQy9BpzDvdXAnHUjNDowYESuHbLYuxMncpbyJEt3JXU\
                                  N92dUffntXgJMEPY8T95yd32MmJ4FrsVCPeG8hD6GWxnf
public version                : tpubD6NzVbkrYhZ4X2yRbxc6pNoJQ1jrnrMgrnL9WKyqeihgRpogakcD16bAQyE7SZ\
                                  PxHA2qN7RaXA3e1crC4x8XqwGGSqSYDpYpTdjMQ28y2rm
tree depth                    : 0
fingerprint                   : c06ea728
parent f'print                : 00000000
child index                   : 0
chain code                    : 45e1569e9708180f71ac2c2bacf43ae8201abc1a988734488cb1932b4de6218f
private key                   : yes
secret exponent               : 114749370691805533845159388135640033077892607693573154669766329279457157068075
 hex                          : fdb1d79b9357e87af3bbee32c00b2b7f9887917f87b36b18715b7cecfb06352b
wif                           : cW5rJwkU8YEVM5oHJ7NAkCKX1XRb6oqUTpGxMjGfvGRhqAZUxANS
 uncompressed                 : 93WeTGaQpUU5A5iJHZi3fLL9cTqAYDsrisayViJ9N8aEnPmbo18
public pair x                 : 9902785663620090184711770704240305868862711997205258022447621751992787903882
public pair y                 : 37415677087283870407237597806492702857184394564495141194068887256230580509154
 x as hex                     : 15e4c72eeca4ba9c0b03b1af6863bab3d65bf1198116b27293b6030a5fdfa58a
 y as hex                     : 52b885d3d7c6d2cd554315e4d4ad1b9879edcfad79c4e8ebfda91aa1b150d9e2
y parity                      : even
key pair as sec               : 0215e4c72eeca4ba9c0b03b1af6863bab3d65bf1198116b27293b6030a5fdfa58a
 uncompressed                 : 0415e4c72eeca4ba9c0b03b1af6863bab3d65bf1198116b27293b6030a5fdfa58a\
                                  52b885d3d7c6d2cd554315e4d4ad1b9879edcfad79c4e8ebfda91aa1b150d9e2
hash160                       : c06ea7281811bbb3cd507606bfbebbd3998e97dd
 uncompressed                 : 09ba135acdd3ef26b94332b52e90cfdf9d69f183
Monacoin address              : my4SbBqL8jnJCT9s99e4CEx5AuQL9gmrF6
Monacoin address uncompressed : mgQPHYHHBZMExct8mPYXtcy8aGMu4T92ZV
Monacoin segwit address       : tmona1qcph2w2qczxam8n2swcrtl04m6wvca97azzacp0
p2sh segwit                   : RnTzFvsgLKHyfC13rXAQ9W5kMJqV5Veva8
 corresponding p2sh script    : 0014c06ea7281811bbb3cd507606bfbebbd3998e97dd
```